### PR TITLE
Add color tags and labels to chat nodes

### DIFF
--- a/src/components/nodes/ChatNode.tsx
+++ b/src/components/nodes/ChatNode.tsx
@@ -1,57 +1,91 @@
-import { useCallback, useEffect, useState, useRef } from 'react';
-import { Handle, Position, NodeResizer, useReactFlow } from '@xyflow/react';
-import type { NodeProps } from '@xyflow/react';
-import { Maximize2, X } from 'lucide-react';
-import type { ChatNode } from '../../types/flow';
-import { useChatStore } from '../../stores/chatStore';
-import { useFlowStore } from '../../stores/flowStore';
-import { useChatNode } from '../../hooks/useChatNode';
-import { streamChat } from '../../services/llm';
-import { calculateBranchPosition } from '../../utils/nodeLayout';
-import { getBranchSystemPrompt } from '../../utils/systemPrompts';
-import { ChatNodeHeader } from './ChatNodeHeader';
-import { ChatMessageList } from './ChatMessageList';
-import { ChatInput } from './ChatInput';
+import { useCallback, useEffect, useState, useRef } from "react";
+import { Handle, Position, NodeResizer, useReactFlow } from "@xyflow/react";
+import type { NodeProps } from "@xyflow/react";
+import { Maximize2, X } from "lucide-react";
+import type { ChatNode } from "../../types/flow";
+import { useChatStore } from "../../stores/chatStore";
+import { useFlowStore } from "../../stores/flowStore";
+import { useChatNode } from "../../hooks/useChatNode";
+import { streamChat } from "../../services/llm";
+import { calculateBranchPosition } from "../../utils/nodeLayout";
+import { getBranchSystemPrompt } from "../../utils/systemPrompts";
+import { ChatNodeHeader } from "./ChatNodeHeader";
+import { ChatMessageList } from "./ChatMessageList";
+import { ChatInput } from "./ChatInput";
+
+const PALETTE_COLORS = [
+  "#ef4444",
+  "#f97316",
+  "#eab308",
+  "#22c55e",
+  "#3b82f6",
+  "#a855f7",
+  "#ec4899",
+  "#6b7280",
+];
 
 export function ChatNodeComponent({ id, data, selected }: NodeProps<ChatNode>) {
-  const { topic, collapsed, minimized, maximized, parentNodeId, branchText, parentNodeIds, mergeAction, color, label } = data;
-  const { sendMessage, cancelStream } = useChatNode(id, topic, parentNodeId, branchText, parentNodeIds as string[] | undefined, mergeAction as string | undefined);
+  const {
+    topic,
+    collapsed,
+    minimized,
+    maximized,
+    parentNodeId,
+    branchText,
+    parentNodeIds,
+    mergeAction,
+    color,
+    label,
+  } = data;
+  const { sendMessage, cancelStream } = useChatNode(
+    id,
+    topic,
+    parentNodeId,
+    branchText,
+    parentNodeIds as string[] | undefined,
+    mergeAction as string | undefined,
+  );
   const { getViewport, setViewport } = useReactFlow();
   const messageCount = useChatStore(
-    (s) => s.conversations[id]?.messages.filter((m) => m.role !== 'system').length ?? 0
+    (s) =>
+      s.conversations[id]?.messages.filter((m) => m.role !== "system").length ??
+      0,
   );
   const [isPaletteOpen, setIsPaletteOpen] = useState(false);
   const popoverRef = useRef<HTMLDivElement | null>(null);
 
+  const updateLabel = (newLabel?: string) => {
+    useFlowStore.getState().updateNodeData(id, {
+      label: newLabel,
+    });
+  };
+
   useEffect(() => {
-    
-  function handleClickOutside(event: MouseEvent) {
-    if (!popoverRef.current) return;
+    function handleClickOutside(event: MouseEvent) {
+      if (!popoverRef.current) return;
 
-    if (!popoverRef.current.contains(event.target as Node)) {
-      setIsPaletteOpen(false);
+      if (!popoverRef.current.contains(event.target as Node)) {
+        updateLabel(label?.trim() || undefined);
+        setIsPaletteOpen(false);
+      }
     }
-  }
 
-  const handleKey = (e: KeyboardEvent) => {
-    if (e.key === 'Escape') {
-      setIsPaletteOpen(false);
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        setIsPaletteOpen(false);
+      }
+    };
+
+    if (isPaletteOpen) {
+      document.addEventListener("mousedown", handleClickOutside);
+      window.addEventListener("keydown", handleKey);
     }
-  };
 
-  if (isPaletteOpen) {
-    window.addEventListener('keydown', handleKey);
-  }
-
-  if (isPaletteOpen) {
-    document.addEventListener('mousedown', handleClickOutside);
-  }
-
-  return () => {
-    document.removeEventListener('mousedown', handleClickOutside);    window.removeEventListener('keydown', handleKey);
-    window.removeEventListener('keydown', handleKey);
-  };
-}, [isPaletteOpen]);
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+      window.removeEventListener("keydown", handleKey);
+    };
+  }, [isPaletteOpen]);
 
   useEffect(() => {
     useChatStore.getState().initConversation(id);
@@ -72,11 +106,17 @@ export function ChatNodeComponent({ id, data, selected }: NodeProps<ChatNode>) {
         n.id === id
           ? {
               ...n,
-              data: { ...n.data, minimized: true, maximized: false, _prevWidth: prevWidth, _prevHeight: prevHeight },
-              style: { ...n.style, width: 'auto', height: 'auto' },
+              data: {
+                ...n.data,
+                minimized: true,
+                maximized: false,
+                _prevWidth: prevWidth,
+                _prevHeight: prevHeight,
+              },
+              style: { ...n.style, width: "auto", height: "auto" },
             }
-          : n
-      )
+          : n,
+      ),
     );
   }, [id]);
 
@@ -95,10 +135,13 @@ export function ChatNodeComponent({ id, data, selected }: NodeProps<ChatNode>) {
               ...n,
               data: { ...n.data, minimized: false, maximized: false },
               style: { ...n.style, width: w, height: h },
-              position: prevX != null && prevY != null ? { x: prevX, y: prevY } : n.position,
+              position:
+                prevX != null && prevY != null
+                  ? { x: prevX, y: prevY }
+                  : n.position,
             }
-          : n
-      )
+          : n,
+      ),
     );
   }, [id]);
 
@@ -125,11 +168,14 @@ export function ChatNodeComponent({ id, data, selected }: NodeProps<ChatNode>) {
                 style: { ...n.style, width: w, height: h },
                 position: { x: prevX, y: prevY },
               }
-            : n
-        )
+            : n,
+        ),
       );
       if (prevZoom) {
-        setViewport({ x: prevVpX, y: prevVpY, zoom: prevZoom }, { duration: 200 });
+        setViewport(
+          { x: prevVpX, y: prevVpY, zoom: prevZoom },
+          { duration: 200 },
+        );
       }
       return;
     }
@@ -141,11 +187,14 @@ export function ChatNodeComponent({ id, data, selected }: NodeProps<ChatNode>) {
     const padding = 40;
 
     // Fixed node dimensions in flow-coordinates — half the screen width at zoom=1
-    const nodeHeight = (window.innerHeight - padding * 2);
+    const nodeHeight = window.innerHeight - padding * 2;
     const nodeWidth = window.innerWidth / 2 - padding * 2;
 
     // Zoom so the node height fills the viewport vertically
-    const zoom = Math.min(Math.max((window.innerHeight - padding * 2) / nodeHeight, 0.1), 2);
+    const zoom = Math.min(
+      Math.max((window.innerHeight - padding * 2) / nodeHeight, 0.1),
+      2,
+    );
 
     // Position the node at the origin for simplicity, then pan viewport to center it
     const nodeX = node.position.x;
@@ -174,8 +223,8 @@ export function ChatNodeComponent({ id, data, selected }: NodeProps<ChatNode>) {
               style: { ...n.style, width: nodeWidth, height: nodeHeight },
               position: { x: nodeX, y: nodeY },
             }
-          : n
-      )
+          : n,
+      ),
     );
     setViewport({ x: vpX, y: vpY, zoom }, { duration: 200 });
   }, [id, maximized, getViewport, setViewport]);
@@ -195,8 +244,10 @@ export function ChatNodeComponent({ id, data, selected }: NodeProps<ChatNode>) {
       if (parentNode.data.maximized) {
         const w = (parentNode.data._prevWidth as number) ?? 400;
         const h = (parentNode.data._prevHeight as number) ?? 500;
-        const prevX = (parentNode.data._prevX as number) ?? parentNode.position.x;
-        const prevY = (parentNode.data._prevY as number) ?? parentNode.position.y;
+        const prevX =
+          (parentNode.data._prevX as number) ?? parentNode.position.x;
+        const prevY =
+          (parentNode.data._prevY as number) ?? parentNode.position.y;
         flowStore.setNodes(
           flowStore.nodes.map((n) =>
             n.id === id
@@ -206,8 +257,8 @@ export function ChatNodeComponent({ id, data, selected }: NodeProps<ChatNode>) {
                   style: { ...n.style, width: w, height: h },
                   position: { x: prevX, y: prevY },
                 }
-              : n
-          )
+              : n,
+          ),
         );
         // Re-read updated node
         parentNode = useFlowStore.getState().nodes.find((n) => n.id === id)!;
@@ -234,7 +285,7 @@ export function ChatNodeComponent({ id, data, selected }: NodeProps<ChatNode>) {
         .map((m) => ({ role: m.role, content: m.content }));
 
       const systemPrompt = getBranchSystemPrompt(topic, parentMessages);
-      chatStore.addMessage(newNodeId, 'system', systemPrompt);
+      chatStore.addMessage(newNodeId, "system", systemPrompt);
 
       // First user message: popup input + highlighted text
       const firstMessage = prompt
@@ -246,14 +297,22 @@ export function ChatNodeComponent({ id, data, selected }: NodeProps<ChatNode>) {
         const store = useChatStore.getState();
         const messages = store.getMessages(newNodeId);
 
-        store.addMessage(newNodeId, 'user', firstMessage);
-        store.addMessage(newNodeId, 'assistant', '');
+        store.addMessage(newNodeId, "user", firstMessage);
+        store.addMessage(newNodeId, "assistant", "");
         store.setStreaming(newNodeId, true);
 
         const controller = new AbortController();
 
         streamChat(
-          [...messages, { id: 'q', role: 'user' as const, content: firstMessage, timestamp: Date.now() }],
+          [
+            ...messages,
+            {
+              id: "q",
+              role: "user" as const,
+              content: firstMessage,
+              timestamp: Date.now(),
+            },
+          ],
           {
             onToken: (token: string) => {
               useChatStore.getState().appendToLastMessage(newNodeId, token);
@@ -262,35 +321,31 @@ export function ChatNodeComponent({ id, data, selected }: NodeProps<ChatNode>) {
               useChatStore.getState().setStreaming(newNodeId, false);
             },
             onError: (error: Error) => {
-              useChatStore.getState().appendToLastMessage(
-                newNodeId,
-                `\n\n**Error:** ${error.message}`
-              );
+              useChatStore
+                .getState()
+                .appendToLastMessage(
+                  newNodeId,
+                  `\n\n**Error:** ${error.message}`,
+                );
               useChatStore.getState().setStreaming(newNodeId, false);
             },
           },
-          controller.signal
+          controller.signal,
         );
       }, 100);
     },
-    [id, topic]
+    [id, topic],
   );
 
   const updateColor = (newColor?: string) => {
     useFlowStore.getState().updateNodeData(id, { color: newColor });
   };
 
-  const updateLabel = (newLabel?: string) => {
-    useFlowStore.getState().updateNodeData(id, {
-      label: newLabel?.trim() || undefined,
-    });
-  };
-
   if (minimized) {
     return (
       <div
         className={`flex items-center gap-2 bg-surface-900 border rounded-full shadow-lg shadow-black/30 px-3 py-1.5 cursor-grab active:cursor-grabbing ${
-          selected ? 'border-accent-500/60' : 'border-neutral-700/50'
+          selected ? "border-accent-500/60" : "border-neutral-700/50"
         } transition-colors`}
         onDoubleClick={handleRestore}
       >
@@ -333,14 +388,14 @@ export function ChatNodeComponent({ id, data, selected }: NodeProps<ChatNode>) {
   }
 
   return (
-      <div
-          className={`relative flex flex-col bg-surface-900 border rounded-xl shadow-xl shadow-black/30 h-full transition-colors ${
-            selected ? 'border-accent-500/60' : 'border-neutral-700/50'
-          }`}
-          style={{
-            borderTop: color ? `4px solid ${color}` : undefined,
-          }}
-      >
+    <div
+      className={`relative flex flex-col bg-surface-900 border rounded-xl shadow-xl shadow-black/30 h-full transition-colors ${
+        selected ? "border-accent-500/60" : "border-neutral-700/50"
+      }`}
+      style={{
+        borderTop: color ? `4px solid ${color}` : undefined,
+      }}
+    >
       <NodeResizer
         minWidth={320}
         minHeight={collapsed ? 52 : 300}
@@ -375,38 +430,30 @@ export function ChatNodeComponent({ id, data, selected }: NodeProps<ChatNode>) {
       />
 
       {isPaletteOpen && (
-        <div   
+        <div
           ref={popoverRef}
           onMouseDown={(e) => e.stopPropagation()}
-          className="absolute top-10 right-3 z-50 bg-neutral-900 border border-neutral-700 rounded-lg p-3 w-48 nodrag">
-    
+          className="absolute top-10 right-3 z-50 bg-neutral-900 border border-neutral-700 rounded-lg p-3 w-48 nodrag"
+        >
           <div className="flex flex-wrap gap-2 mb-2">
-          {[
-            '#ef4444',
-            '#f97316',
-            '#eab308',
-            '#22c55e',
-            '#3b82f6',
-            '#a855f7',
-            '#ec4899',
-            '#6b7280',
-          ].map((c) => (
-            <button
-              key={c}
-              onClick={() => updateColor(color === c ? undefined : c)}
-              className={`w-5 h-5 rounded-full border-2 ${
-                color === c ? 'border-white' : 'border-transparent'
-              }`}
-              style={{ backgroundColor: c }}
-            />
-          ))}
+            {PALETTE_COLORS.map((c) => (
+              <button
+                key={c}
+                onClick={() => updateColor(color === c ? undefined : c)}
+                className={`w-5 h-5 rounded-full border-2 ${
+                  color === c ? "border-white" : "border-transparent"
+                }`}
+                style={{ backgroundColor: c }}
+              />
+            ))}
           </div>
 
           <input
-            value={label ?? ''}
+            value={label ?? ""}
             onChange={(e) => updateLabel(e.target.value)}
             onKeyDown={(e) => {
-              if (e.key === 'Enter') {
+              if (e.key === "Enter") {
+                updateLabel(label?.trim() || undefined);
                 setIsPaletteOpen(false);
               }
             }}

--- a/src/components/nodes/ChatNode.tsx
+++ b/src/components/nodes/ChatNode.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect } from 'react';
+import { useCallback, useEffect, useState, useRef } from 'react';
 import { Handle, Position, NodeResizer, useReactFlow } from '@xyflow/react';
 import type { NodeProps } from '@xyflow/react';
 import { Maximize2, X } from 'lucide-react';
@@ -14,12 +14,44 @@ import { ChatMessageList } from './ChatMessageList';
 import { ChatInput } from './ChatInput';
 
 export function ChatNodeComponent({ id, data, selected }: NodeProps<ChatNode>) {
-  const { topic, collapsed, minimized, maximized, parentNodeId, branchText, parentNodeIds, mergeAction } = data;
+  const { topic, collapsed, minimized, maximized, parentNodeId, branchText, parentNodeIds, mergeAction, color, label } = data;
   const { sendMessage, cancelStream } = useChatNode(id, topic, parentNodeId, branchText, parentNodeIds as string[] | undefined, mergeAction as string | undefined);
   const { getViewport, setViewport } = useReactFlow();
   const messageCount = useChatStore(
     (s) => s.conversations[id]?.messages.filter((m) => m.role !== 'system').length ?? 0
   );
+  const [isPaletteOpen, setIsPaletteOpen] = useState(false);
+  const popoverRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    
+  function handleClickOutside(event: MouseEvent) {
+    if (!popoverRef.current) return;
+
+    if (!popoverRef.current.contains(event.target as Node)) {
+      setIsPaletteOpen(false);
+    }
+  }
+
+  const handleKey = (e: KeyboardEvent) => {
+    if (e.key === 'Escape') {
+      setIsPaletteOpen(false);
+    }
+  };
+
+  if (isPaletteOpen) {
+    window.addEventListener('keydown', handleKey);
+  }
+
+  if (isPaletteOpen) {
+    document.addEventListener('mousedown', handleClickOutside);
+  }
+
+  return () => {
+    document.removeEventListener('mousedown', handleClickOutside);    window.removeEventListener('keydown', handleKey);
+    window.removeEventListener('keydown', handleKey);
+  };
+}, [isPaletteOpen]);
 
   useEffect(() => {
     useChatStore.getState().initConversation(id);
@@ -244,6 +276,16 @@ export function ChatNodeComponent({ id, data, selected }: NodeProps<ChatNode>) {
     [id, topic]
   );
 
+  const updateColor = (newColor?: string) => {
+    useFlowStore.getState().updateNodeData(id, { color: newColor });
+  };
+
+  const updateLabel = (newLabel?: string) => {
+    useFlowStore.getState().updateNodeData(id, {
+      label: newLabel?.trim() || undefined,
+    });
+  };
+
   if (minimized) {
     return (
       <div
@@ -291,13 +333,14 @@ export function ChatNodeComponent({ id, data, selected }: NodeProps<ChatNode>) {
   }
 
   return (
-    <div
-      className={`flex flex-col bg-surface-900 border rounded-xl shadow-xl shadow-black/30 h-full ${
-        selected
-          ? 'border-accent-500/60'
-          : 'border-neutral-700/50'
-      } transition-colors`}
-    >
+      <div
+          className={`relative flex flex-col bg-surface-900 border rounded-xl shadow-xl shadow-black/30 h-full transition-colors ${
+            selected ? 'border-accent-500/60' : 'border-neutral-700/50'
+          }`}
+          style={{
+            borderTop: color ? `4px solid ${color}` : undefined,
+          }}
+      >
       <NodeResizer
         minWidth={320}
         minHeight={collapsed ? 52 : 300}
@@ -326,7 +369,63 @@ export function ChatNodeComponent({ id, data, selected }: NodeProps<ChatNode>) {
         onMinimize={handleMinimize}
         onMaximize={handleMaximize}
         onClose={handleClose}
+        onTogglePalette={() => setIsPaletteOpen((p) => !p)}
+        color={color}
+        label={label}
       />
+
+      {isPaletteOpen && (
+        <div   
+          ref={popoverRef}
+          onMouseDown={(e) => e.stopPropagation()}
+          className="absolute top-10 right-3 z-50 bg-neutral-900 border border-neutral-700 rounded-lg p-3 w-48 nodrag">
+    
+          <div className="flex flex-wrap gap-2 mb-2">
+          {[
+            '#ef4444',
+            '#f97316',
+            '#eab308',
+            '#22c55e',
+            '#3b82f6',
+            '#a855f7',
+            '#ec4899',
+            '#6b7280',
+          ].map((c) => (
+            <button
+              key={c}
+              onClick={() => updateColor(color === c ? undefined : c)}
+              className={`w-5 h-5 rounded-full border-2 ${
+                color === c ? 'border-white' : 'border-transparent'
+              }`}
+              style={{ backgroundColor: c }}
+            />
+          ))}
+          </div>
+
+          <input
+            value={label ?? ''}
+            onChange={(e) => updateLabel(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') {
+                setIsPaletteOpen(false);
+              }
+            }}
+            placeholder="Add label..."
+            maxLength={20}
+            className="w-full text-xs bg-neutral-800 px-2 py-1 rounded outline-none"
+          />
+
+          <button
+            onClick={() => {
+              updateColor(undefined);
+              updateLabel(undefined);
+            }}
+            className="text-xs text-red-400 mt-2"
+          >
+            Clear
+          </button>
+        </div>
+      )}
 
       {!collapsed && (
         <>

--- a/src/components/nodes/ChatNodeHeader.tsx
+++ b/src/components/nodes/ChatNodeHeader.tsx
@@ -44,8 +44,8 @@ export function ChatNodeHeader({
             <span
               className="text-[10px] px-2 py-0.5 rounded-full"
               style={{
-                backgroundColor: color ? `${color}20` : undefined,
-                color: color,
+                backgroundColor: color ? `${color}20` : "bg-neutral-800",
+                color: color ? color : "text-neutral-400",
               }}
             >
               {label}

--- a/src/components/nodes/ChatNodeHeader.tsx
+++ b/src/components/nodes/ChatNodeHeader.tsx
@@ -1,4 +1,4 @@
-import { ChevronDown, ChevronRight, Minus, Maximize2, X } from 'lucide-react';
+import { ChevronDown, ChevronRight, Minus, Maximize2, X, Palette } from 'lucide-react';
 
 interface ChatNodeHeaderProps {
   topic: string;
@@ -8,6 +8,9 @@ interface ChatNodeHeaderProps {
   onMinimize: () => void;
   onMaximize: () => void;
   onClose: () => void;
+  onTogglePalette:() => void
+  color?:string
+  label?:string
 }
 
 export function ChatNodeHeader({
@@ -18,6 +21,9 @@ export function ChatNodeHeader({
   onMinimize,
   onMaximize,
   onClose,
+  onTogglePalette,
+  color,
+  label
 }: ChatNodeHeaderProps) {
   return (
     <div className="flex items-center gap-2 px-3 py-2 border-b border-neutral-700/50 bg-neutral-800/30 rounded-t-xl cursor-grab active:cursor-grabbing">
@@ -29,9 +35,23 @@ export function ChatNodeHeader({
         {collapsed ? <ChevronRight size={14} /> : <ChevronDown size={14} />}
       </button>
       <div className="flex-1 min-w-0">
-        <span className="text-xs font-medium text-accent-400 bg-accent-500/10 px-2 py-0.5 rounded-full truncate inline-block max-w-full">
-          {topic}
-        </span>
+        <div className="flex items-center gap-2 min-w-0">
+          <span className="text-xs font-medium text-accent-400 bg-accent-500/10 px-2 py-0.5 rounded-full truncate">
+            {topic}
+          </span>
+
+          {label && (
+            <span
+              className="text-[10px] px-2 py-0.5 rounded-full"
+              style={{
+                backgroundColor: color ? `${color}20` : undefined,
+                color: color,
+              }}
+            >
+              {label}
+            </span>
+          )}
+      </div>
       </div>
       <button
         onClick={onMinimize}
@@ -50,6 +70,13 @@ export function ChatNodeHeader({
         title={maximized ? 'Restore size' : 'Maximize'}
       >
         <Maximize2 size={14} />
+      </button>
+      <button
+        onClick={onTogglePalette}
+        className="nodrag transition-colors text-neutral-500 hover:text-neutral-200"
+        title="Add label and color"
+        >
+        <Palette size={14} />
       </button>
       <button
         onClick={onClose}

--- a/src/stores/__tests__/flowStore.test.ts
+++ b/src/stores/__tests__/flowStore.test.ts
@@ -163,4 +163,69 @@ describe('flowStore', () => {
       expect(useFlowStore.getState().edges).toHaveLength(0);
     });
   });
+
+  describe('updateNodeData', () => {
+
+    it('updates node color', () => {
+  const id = useFlowStore.getState().addChatNode(
+    { x: 0, y: 0 },
+    { topic: 'Test' }
+  );
+
+  useFlowStore.getState().updateNodeData(id, { color: '#ef4444' });
+
+  const node = useFlowStore.getState().nodes.find((n) => n.id === id);
+
+  expect(node?.data.color).toBe('#ef4444');
+    });
+
+    it('updates node label', () => {
+      const id = useFlowStore.getState().addChatNode(
+        { x: 0, y: 0 },
+        { topic: 'Test' }
+      );
+
+      useFlowStore.getState().updateNodeData(id, { label: 'Research' });
+
+      const node = useFlowStore.getState().nodes.find((n) => n.id === id);
+
+      expect(node?.data.label).toBe('Research');
+    });
+
+    it('clears color and label when undefined is passed', () => {
+      const id = useFlowStore.getState().addChatNode(
+        { x: 0, y: 0 },
+        { topic: 'Test', color: '#fff', label: 'Temp' }
+      );
+
+      useFlowStore.getState().updateNodeData(id, {
+        color: undefined,
+        label: undefined,
+      });
+
+      const node = useFlowStore.getState().nodes.find((n) => n.id === id);
+
+      expect(node?.data.color).toBeUndefined();
+      expect(node?.data.label).toBeUndefined();
+    });
+
+    it('does not overwrite other node data fields when updating color/label', () => {
+      const id = useFlowStore.getState().addChatNode(
+        { x: 0, y: 0 },
+        { topic: 'Original', collapsed: true }
+      );
+
+      useFlowStore.getState().updateNodeData(id, {
+        color: '#22c55e',
+        label: 'Approved',
+      });
+
+      const node = useFlowStore.getState().nodes.find((n) => n.id === id);
+
+      expect(node?.data.topic).toBe('Original');
+      expect(node?.data.collapsed).toBe(true);
+      expect(node?.data.color).toBe('#22c55e');
+      expect(node?.data.label).toBe('Approved');
+    });
+  })
 });

--- a/src/types/flow.ts
+++ b/src/types/flow.ts
@@ -10,6 +10,8 @@ export interface ChatNodeData {
   minimized?: boolean;
   maximized?: boolean;
   [key: string]: unknown;
+  color?: string
+  label?: string
 }
 
 export type ChatNode = Node<ChatNodeData, 'chat'>;


### PR DESCRIPTION
**Summary**

This PR adds visual categorization to chat nodes by allowing users to assign a color and an optional label to each node.

This improves usability when working with large canvases by helping users quickly identify and group related conversations.

**Features**

Add color tagging to nodes using a predefined palette
Add optional short text labels (max ~20 chars)
Visual enhancements:
Colored top border on nodes
Label displayed as a tag in the node header
Inline popover UI for selecting color and label

**preview** 

<img width="403" height="274" alt="Screenshot 2026-04-01 at 10 33 41 PM" src="https://github.com/user-attachments/assets/6722e199-7081-436a-801b-df84be69a700" />

<img width="405" height="525" alt="Screenshot 2026-04-01 at 10 33 52 PM" src="https://github.com/user-attachments/assets/97eb2082-975e-48a1-bd4a-5ce8b3493ada" />


**Closes** 
PR - #10 