### PR TITLE
fix: correct label styling fallback and stale closure in color tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Color tags and labels on chat nodes — palette picker with 8 colors and custom text labels (#16)
+- Copy-to-clipboard button on chat messages (#15)
+
+### Fixed
+
+- Label badge fallback styling used Tailwind class names instead of CSS values, rendering no styles when no color was set
+- Stale closure in palette click-outside handler caused trim to use outdated label value
+
 ## [1.0.1] - 2026-03-28
 
 ### Added

--- a/src/components/nodes/ChatNode.tsx
+++ b/src/components/nodes/ChatNode.tsx
@@ -53,19 +53,22 @@ export function ChatNodeComponent({ id, data, selected }: NodeProps<ChatNode>) {
   );
   const [isPaletteOpen, setIsPaletteOpen] = useState(false);
   const popoverRef = useRef<HTMLDivElement | null>(null);
+  const labelRef = useRef(label);
+  useEffect(() => { labelRef.current = label; }, [label]);
 
-  const updateLabel = (newLabel?: string) => {
+  const updateLabel = useCallback((newLabel?: string) => {
     useFlowStore.getState().updateNodeData(id, {
       label: newLabel,
     });
-  };
+  }, [id]);
 
   useEffect(() => {
     function handleClickOutside(event: MouseEvent) {
       if (!popoverRef.current) return;
 
       if (!popoverRef.current.contains(event.target as Node)) {
-        updateLabel(label?.trim() || undefined);
+        const trimmed = labelRef.current?.trim() || undefined;
+        useFlowStore.getState().updateNodeData(id, { label: trimmed });
         setIsPaletteOpen(false);
       }
     }
@@ -85,7 +88,7 @@ export function ChatNodeComponent({ id, data, selected }: NodeProps<ChatNode>) {
       document.removeEventListener("mousedown", handleClickOutside);
       window.removeEventListener("keydown", handleKey);
     };
-  }, [isPaletteOpen]);
+  }, [isPaletteOpen, id]);
 
   useEffect(() => {
     useChatStore.getState().initConversation(id);

--- a/src/components/nodes/ChatNodeHeader.tsx
+++ b/src/components/nodes/ChatNodeHeader.tsx
@@ -44,8 +44,8 @@ export function ChatNodeHeader({
             <span
               className="text-[10px] px-2 py-0.5 rounded-full"
               style={{
-                backgroundColor: color ? `${color}20` : "bg-neutral-800",
-                color: color ? color : "text-neutral-400",
+                backgroundColor: color ? `${color}20` : '#262626',
+                color: color ?? '#a3a3a3',
               }}
             >
               {label}


### PR DESCRIPTION
The label badge used Tailwind class names as inline CSS values, rendering no fallback styles. The palette click-outside handler captured a stale label reference, trimming an outdated value. Also adds missing changelog entries for PRs #15 and #16.