### PR TITLE
Add confirmation popup before deleting chat node

### DIFF
--- a/src/components/nodes/ChatNode.tsx
+++ b/src/components/nodes/ChatNode.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { Handle, Position, NodeResizer, useReactFlow } from '@xyflow/react';
 import type { NodeProps } from '@xyflow/react';
 import { Maximize2, X } from 'lucide-react';
@@ -14,8 +14,17 @@ import { ChatMessageList } from './ChatMessageList';
 import { ChatInput } from './ChatInput';
 import { ChatNodeDeleteConfirmation } from './ChatNodeDeleteConfirmation';
 
+const PALETTE_COLORS = [
+  '#22c55e',
+  '#3b82f6',
+  '#f59e0b',
+  '#ef4444',
+  '#a855f7',
+  '#06b6d4',
+];
+
 export function ChatNodeComponent({ id, data, selected }: NodeProps<ChatNode>) {
-  const { topic, collapsed, minimized, maximized, parentNodeId, branchText, parentNodeIds, mergeAction } = data;
+  const { topic, collapsed, minimized, maximized, parentNodeId, branchText, parentNodeIds, mergeAction, color, label } = data;
   const [showDeleteConfirmation, setShowDeleteConfirmation] = useState(false);
   const { sendMessage, cancelStream } = useChatNode(id, topic, parentNodeId, branchText, parentNodeIds as string[] | undefined, mergeAction as string | undefined);
   const { getViewport, setViewport } = useReactFlow();

--- a/src/components/nodes/ChatNode.tsx
+++ b/src/components/nodes/ChatNode.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { Handle, Position, NodeResizer, useReactFlow } from '@xyflow/react';
 import type { NodeProps } from '@xyflow/react';
 import { Maximize2, X } from 'lucide-react';
@@ -12,9 +12,11 @@ import { getBranchSystemPrompt } from '../../utils/systemPrompts';
 import { ChatNodeHeader } from './ChatNodeHeader';
 import { ChatMessageList } from './ChatMessageList';
 import { ChatInput } from './ChatInput';
+import { ChatNodeDeleteConfirmation } from './ChatNodeDeleteConfirmation';
 
 export function ChatNodeComponent({ id, data, selected }: NodeProps<ChatNode>) {
   const { topic, collapsed, minimized, maximized, parentNodeId, branchText, parentNodeIds, mergeAction } = data;
+  const [showDeleteConfirmation, setShowDeleteConfirmation] = useState(false);
   const { sendMessage, cancelStream } = useChatNode(id, topic, parentNodeId, branchText, parentNodeIds as string[] | undefined, mergeAction as string | undefined);
   const { getViewport, setViewport } = useReactFlow();
   const messageCount = useChatStore(
@@ -149,6 +151,14 @@ export function ChatNodeComponent({ id, data, selected }: NodeProps<ChatNode>) {
   }, [id, maximized, getViewport, setViewport]);
 
   const handleClose = useCallback(() => {
+    setShowDeleteConfirmation(true);
+  }, []);
+
+  const handleCancelDelete = useCallback(() => {
+    setShowDeleteConfirmation(false);
+  }, []);
+
+  const handleConfirmDelete = useCallback(() => {
     useFlowStore.getState().removeNode(id);
     useChatStore.getState().removeConversation(id);
   }, [id]);
@@ -247,7 +257,7 @@ export function ChatNodeComponent({ id, data, selected }: NodeProps<ChatNode>) {
   if (minimized) {
     return (
       <div
-        className={`flex items-center gap-2 bg-surface-900 border rounded-full shadow-lg shadow-black/30 px-3 py-1.5 cursor-grab active:cursor-grabbing ${
+        className={`relative flex items-center gap-2 bg-surface-900 border rounded-full shadow-lg shadow-black/30 px-3 py-1.5 cursor-grab active:cursor-grabbing ${
           selected ? 'border-accent-500/60' : 'border-neutral-700/50'
         } transition-colors`}
         onDoubleClick={handleRestore}
@@ -286,13 +296,20 @@ export function ChatNodeComponent({ id, data, selected }: NodeProps<ChatNode>) {
         >
           <X size={12} />
         </button>
+        {showDeleteConfirmation && (
+          <ChatNodeDeleteConfirmation
+            topic={topic}
+            onConfirm={handleConfirmDelete}
+            onCancel={handleCancelDelete}
+          />
+        )}
       </div>
     );
   }
 
   return (
     <div
-      className={`flex flex-col bg-surface-900 border rounded-xl shadow-xl shadow-black/30 h-full ${
+      className={`relative flex flex-col bg-surface-900 border rounded-xl shadow-xl shadow-black/30 h-full ${
         selected
           ? 'border-accent-500/60'
           : 'border-neutral-700/50'
@@ -327,6 +344,13 @@ export function ChatNodeComponent({ id, data, selected }: NodeProps<ChatNode>) {
         onMaximize={handleMaximize}
         onClose={handleClose}
       />
+      {showDeleteConfirmation && (
+        <ChatNodeDeleteConfirmation
+          topic={topic}
+          onConfirm={handleConfirmDelete}
+          onCancel={handleCancelDelete}
+        />
+      )}
 
       {!collapsed && (
         <>

--- a/src/components/nodes/ChatNodeDeleteConfirmation.tsx
+++ b/src/components/nodes/ChatNodeDeleteConfirmation.tsx
@@ -1,0 +1,101 @@
+import { useEffect, useRef } from 'react';
+import { AlertTriangle, Trash2, X } from 'lucide-react';
+
+interface ChatNodeDeleteConfirmationProps {
+  topic: string;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+export function ChatNodeDeleteConfirmation({
+  topic,
+  onConfirm,
+  onCancel,
+}: ChatNodeDeleteConfirmationProps) {
+  const popupRef = useRef<HTMLDivElement>(null);
+  const truncatedTopic = topic.length > 48 ? topic.slice(0, 48) + '...' : topic;
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        onCancel();
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [onCancel]);
+
+  useEffect(() => {
+    const handleMouseDown = (e: MouseEvent) => {
+      const target = e.target as Node | null;
+      if (target && popupRef.current?.contains(target)) return;
+      onCancel();
+    };
+
+    document.addEventListener('mousedown', handleMouseDown);
+    return () => document.removeEventListener('mousedown', handleMouseDown);
+  }, [onCancel]);
+
+  return (
+    <div
+      ref={popupRef}
+      className="nodrag nopan nowheel absolute right-2 top-10 z-50 w-72 rounded-lg border border-red-500/30 bg-surface-800 shadow-xl shadow-black/50"
+      onPointerDown={(e) => e.stopPropagation()}
+      onMouseDown={(e) => e.stopPropagation()}
+      role="dialog"
+      aria-modal="false"
+      aria-labelledby="delete-chat-node-title"
+    >
+      <div className="px-3 pt-2.5 pb-2">
+        <div className="flex items-start gap-2">
+          <AlertTriangle size={15} className="mt-0.5 shrink-0 text-red-400" />
+          <div className="min-w-0 flex-1">
+            <div
+              id="delete-chat-node-title"
+              className="text-xs font-medium text-neutral-200"
+            >
+              Delete this chat?
+            </div>
+            <p className="mt-1 text-[11px] leading-4 text-neutral-400">
+              This removes &ldquo;{truncatedTopic}&rdquo; and its conversation history.
+            </p>
+          </div>
+          <button
+            onClick={(e) => {
+              e.stopPropagation();
+              onCancel();
+            }}
+            className="shrink-0 text-neutral-500 hover:text-neutral-200 transition-colors"
+            title="Cancel"
+            aria-label="Cancel delete"
+          >
+            <X size={12} />
+          </button>
+        </div>
+      </div>
+
+      <div className="border-t border-neutral-700/30 px-1.5 py-1 flex justify-end gap-1">
+        <button
+          className="text-xs text-neutral-400 hover:text-neutral-200 hover:bg-neutral-700/50 rounded-md px-2 py-1 transition-colors"
+          onClick={(e) => {
+            e.stopPropagation();
+            onCancel();
+          }}
+        >
+          Cancel
+        </button>
+        <button
+          className="flex items-center gap-1.5 text-xs text-red-300 hover:text-red-200 hover:bg-red-500/10 rounded-md px-2 py-1 transition-colors"
+          onClick={(e) => {
+            e.stopPropagation();
+            onConfirm();
+          }}
+        >
+          <Trash2 size={12} />
+          <span>Delete</span>
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/nodes/__tests__/ChatNodeDeleteConfirmation.test.tsx
+++ b/src/components/nodes/__tests__/ChatNodeDeleteConfirmation.test.tsx
@@ -1,0 +1,93 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi, beforeEach, afterEach, type Mock } from 'vitest';
+import { createRoot, type Root } from 'react-dom/client';
+import { act } from 'react-dom/test-utils';
+import { ChatNodeDeleteConfirmation } from '../ChatNodeDeleteConfirmation';
+
+describe('ChatNodeDeleteConfirmation', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  let onConfirm: Mock<() => void>;
+  let onCancel: Mock<() => void>;
+
+  const renderPopup = () => {
+    act(() => {
+      root.render(
+        <ChatNodeDeleteConfirmation
+          topic="A conversation worth keeping"
+          onConfirm={onConfirm}
+          onCancel={onCancel}
+        />,
+      );
+    });
+  };
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+    onConfirm = vi.fn();
+    onCancel = vi.fn();
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  it('confirms deletion from the Delete button', () => {
+    renderPopup();
+
+    const deleteButton = Array.from(container.querySelectorAll('button')).find(
+      (button) => button.textContent?.includes('Delete'),
+    );
+
+    act(() => {
+      deleteButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    expect(onConfirm).toHaveBeenCalledOnce();
+    expect(onCancel).not.toHaveBeenCalled();
+  });
+
+  it('cancels from the Cancel button', () => {
+    renderPopup();
+
+    const cancelButton = Array.from(container.querySelectorAll('button')).find(
+      (button) => button.textContent === 'Cancel',
+    );
+
+    act(() => {
+      cancelButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    expect(onCancel).toHaveBeenCalledOnce();
+    expect(onConfirm).not.toHaveBeenCalled();
+  });
+
+  it('cancels when Escape is pressed', () => {
+    renderPopup();
+
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+    });
+
+    expect(onCancel).toHaveBeenCalledOnce();
+    expect(onConfirm).not.toHaveBeenCalled();
+  });
+
+  it('cancels when clicking outside the popup', () => {
+    renderPopup();
+
+    act(() => {
+      document.body.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
+    });
+
+    expect(onCancel).toHaveBeenCalledOnce();
+    expect(onConfirm).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
# Summary
Adds a confirmation step before deleting a chat node so users do not accidentally lose conversation history.

# Changes
- Added a ChatNodeDeleteConfirmation popup with Delete and Cancel actions.
- Updated chat node close behavior so clicking the close button opens the confirmation instead of immediately removing the node.
- Applied the confirmation flow to both full-size and minimized chat nodes.
- Added dismissal behavior for Escape key and outside clicks.
- Added regression tests for confirm, cancel, Escape, and outside-click behavior.

# Preview
<img width="1920" height="891" alt="Screenshot (52)" src="https://github.com/user-attachments/assets/b650a1f9-adee-46eb-b921-b1ee30340d3c" />
<img width="1916" height="894" alt="Screenshot 2026-04-15 161441" src="https://github.com/user-attachments/assets/17511bbc-0278-4c80-9543-c3966e780859" />
