### PR TITLE
feat: add auto-layout button for node tree

### DIFF
--- a/src/components/canvas/CanvasControls.tsx
+++ b/src/components/canvas/CanvasControls.tsx
@@ -8,11 +8,13 @@ import {
   Settings,
   Plus,
   HelpCircle,
+  Network,
 } from 'lucide-react';
 import { useSettingsStore } from '../../stores/settingsStore';
 import { useFlowStore } from '../../stores/flowStore';
 import { useChatStore } from '../../stores/chatStore';
 import { HelpGuidePanel } from '../ui/HelpGuide';
+import { calculateAutoLayoutPositions } from '../../utils/nodeLayout';
 
 export function CanvasControls() {
   const { zoomIn, zoomOut, fitView, getViewport } = useReactFlow();
@@ -33,6 +35,27 @@ export function CanvasControls() {
     useChatStore.getState().initConversation(nodeId);
   };
 
+  const handleAutoArrange = () => {
+    const flowStore = useFlowStore.getState();
+    const positions = calculateAutoLayoutPositions(flowStore.nodes, flowStore.edges, {
+      horizontalGap: 100,
+      verticalGap: 40,
+      componentGap: 200,
+      origin: { x: 0, y: 0 },
+    });
+
+    flowStore.setNodes(
+      flowStore.nodes.map((node) => {
+        const position = positions[node.id];
+        if (!position) return node;
+        return {
+          ...node,
+          position,
+        };
+      })
+    );
+  };
+
   const btnClass =
     'p-2 rounded-lg bg-surface-900 border border-neutral-700/50 text-neutral-400 hover:text-neutral-200 hover:bg-surface-800 transition-colors';
 
@@ -51,6 +74,9 @@ export function CanvasControls() {
         </button>
         <button onClick={() => fitView({ padding: 0.2 })} className={btnClass} title="Fit View">
           <Maximize size={18} />
+        </button>
+        <button onClick={handleAutoArrange} className={btnClass} title="Auto-arrange nodes">
+          <Network size={18} />
         </button>
         <div className="h-px bg-neutral-700/50 my-0.5" />
         <button

--- a/src/components/canvas/CanvasControls.tsx
+++ b/src/components/canvas/CanvasControls.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useReactFlow } from '@xyflow/react';
 import {
   ZoomIn,
@@ -22,6 +22,16 @@ export function CanvasControls() {
   const showMinimap = useSettingsStore((s) => s.showMinimap);
   const toggleSettings = useSettingsStore((s) => s.toggleSettings);
   const [showHelp, setShowHelp] = useState(false);
+  const arrangeTimerRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (arrangeTimerRef.current !== null) {
+        window.clearTimeout(arrangeTimerRef.current);
+      }
+      document.querySelector('.react-flow')?.classList.remove('auto-arranging');
+    };
+  }, []);
 
   const handleNewNode = () => {
     const viewport = getViewport();
@@ -37,6 +47,14 @@ export function CanvasControls() {
 
   const handleAutoArrange = () => {
     const flowStore = useFlowStore.getState();
+    const flowElement = document.querySelector('.react-flow');
+
+    if (arrangeTimerRef.current !== null) {
+      window.clearTimeout(arrangeTimerRef.current);
+    }
+
+    flowElement?.classList.add('auto-arranging');
+
     const positions = calculateAutoLayoutPositions(flowStore.nodes, flowStore.edges, {
       horizontalGap: 100,
       verticalGap: 40,
@@ -54,6 +72,12 @@ export function CanvasControls() {
         };
       })
     );
+
+    arrangeTimerRef.current = window.setTimeout(() => {
+      fitView({ padding: 0.2 });
+      flowElement?.classList.remove('auto-arranging');
+      arrangeTimerRef.current = null;
+    }, 320);
   };
 
   const btnClass =

--- a/src/index.css
+++ b/src/index.css
@@ -57,12 +57,8 @@ html, body, #root {
   border: none !important;
 }
 
-.react-flow__node {
+.auto-arranging .react-flow__node {
   transition: transform 300ms ease-out;
-}
-
-.react-flow__node.dragging {
-  transition: none;
 }
 
 /* Re-enable text selection inside message areas (React Flow sets user-select: none on nodes) */

--- a/src/index.css
+++ b/src/index.css
@@ -57,6 +57,14 @@ html, body, #root {
   border: none !important;
 }
 
+.react-flow__node {
+  transition: transform 300ms ease-out;
+}
+
+.react-flow__node.dragging {
+  transition: none;
+}
+
 /* Re-enable text selection inside message areas (React Flow sets user-select: none on nodes) */
 .react-flow__node .select-text,
 .react-flow__node .select-text * {

--- a/src/utils/__tests__/nodeLayout.test.ts
+++ b/src/utils/__tests__/nodeLayout.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import { calculateBranchPosition, calculateMergePosition } from '../nodeLayout';
-import type { ChatNode } from '../../types/flow';
+import {
+  calculateAutoLayoutPositions,
+  calculateBranchPosition,
+  calculateMergePosition,
+} from '../nodeLayout';
+import type { ChatNode, TopicEdge } from '../../types/flow';
 
 function makeNode(
   id: string,
@@ -18,6 +22,18 @@ function makeNode(
       ...(width !== undefined && { width }),
       ...(height !== undefined && { height }),
     },
+  };
+}
+
+function makeEdge(source: string, target: string): TopicEdge {
+  return {
+    id: `e-${source}-${target}`,
+    source,
+    target,
+    sourceHandle: 'right',
+    targetHandle: 'left',
+    type: 'topic',
+    data: { label: `${source}->${target}` },
   };
 }
 
@@ -104,5 +120,80 @@ describe('calculateMergePosition', () => {
     expect(pos.x).toBe(700 + 100); // rightmost edge + gap
     // minY=0, maxY=1300, center=650, offset=650-250=400
     expect(pos.y).toBe(400);
+  });
+});
+
+describe('calculateAutoLayoutPositions', () => {
+  it('places root nodes at the leftmost column', () => {
+    const root = makeNode('root', 500, 100);
+    const child = makeNode('child', 900, 300);
+    const positions = calculateAutoLayoutPositions(
+      [root, child],
+      [makeEdge('root', 'child')]
+    );
+
+    expect(positions.root.x).toBe(0);
+    expect(positions.child.x).toBeGreaterThan(positions.root.x);
+  });
+
+  it('places children one level to the right of their parent', () => {
+    const root = makeNode('root', 0, 100);
+    const c1 = makeNode('c1', 0, 200);
+    const c2 = makeNode('c2', 0, 300);
+    const positions = calculateAutoLayoutPositions(
+      [root, c1, c2],
+      [makeEdge('root', 'c1'), makeEdge('root', 'c2')]
+    );
+
+    expect(positions.c1.x).toBeGreaterThan(positions.root.x);
+    expect(positions.c2.x).toBe(positions.c1.x);
+  });
+
+  it('places merge nodes at deepest parent level + 1', () => {
+    const root = makeNode('root', 0, 0);
+    const a = makeNode('a', 0, 0);
+    const b = makeNode('b', 0, 0);
+    const d = makeNode('d', 0, 0);
+    const merge = makeNode('merge', 0, 0);
+    const edges = [
+      makeEdge('root', 'a'),
+      makeEdge('root', 'b'),
+      makeEdge('a', 'd'),
+      makeEdge('a', 'merge'),
+      makeEdge('b', 'merge'),
+    ];
+
+    const positions = calculateAutoLayoutPositions([root, a, b, d, merge], edges);
+    expect(positions.a.x).toBe(positions.b.x);
+    expect(positions.merge.x).toBeGreaterThan(positions.a.x);
+    expect(positions.merge.x).toBe(positions.d.x);
+  });
+
+  it("stacks disconnected subgraphs so they don't overlap", () => {
+    const a1 = makeNode('a1', 0, 0, 400, 500);
+    const a2 = makeNode('a2', 0, 0, 400, 500);
+    const b1 = makeNode('b1', 0, 0, 400, 500);
+    const b2 = makeNode('b2', 0, 0, 400, 500);
+
+    const positions = calculateAutoLayoutPositions(
+      [a1, a2, b1, b2],
+      [makeEdge('a1', 'a2'), makeEdge('b1', 'b2')]
+    );
+
+    const componentAIds = ['a1', 'a2'];
+    const componentBIds = ['b1', 'b2'];
+    const componentABottom = Math.max(
+      ...componentAIds.map((id) => positions[id].y + 500)
+    );
+    const componentBTop = Math.min(...componentBIds.map((id) => positions[id].y));
+
+    expect(componentBTop).toBeGreaterThan(componentABottom);
+  });
+
+  it('keeps a single node in place when there are no edges', () => {
+    const solo = makeNode('solo', 123, 456);
+    const positions = calculateAutoLayoutPositions([solo], []);
+
+    expect(positions.solo).toEqual({ x: 123, y: 456 });
   });
 });

--- a/src/utils/nodeLayout.ts
+++ b/src/utils/nodeLayout.ts
@@ -1,9 +1,10 @@
-import type { ChatNode } from '../types/flow';
+import type { ChatNode, TopicEdge } from '../types/flow';
 
 const NODE_WIDTH = 400;
 const HORIZONTAL_GAP = 100;
 const VERTICAL_GAP = 40;
 const NODE_HEIGHT = 500;
+const COMPONENT_GAP = 200;
 
 export function calculateMergePosition(
   parentNodes: ChatNode[]
@@ -43,4 +44,281 @@ export function calculateBranchPosition(
     parentY + existingChildCount * (NODE_HEIGHT + VERTICAL_GAP);
 
   return { x, y };
+}
+
+interface AutoLayoutOptions {
+  horizontalGap?: number;
+  verticalGap?: number;
+  componentGap?: number;
+  origin?: { x: number; y: number };
+}
+
+interface NodeMetrics {
+  width: number;
+  height: number;
+}
+
+export function calculateAutoLayoutPositions(
+  nodes: ChatNode[],
+  edges: TopicEdge[],
+  options: AutoLayoutOptions = {}
+): Record<string, { x: number; y: number }> {
+  if (nodes.length === 0) return {};
+  if (nodes.length === 1 && edges.length === 0) {
+    const singleNode = nodes[0];
+    return {
+      [singleNode.id]: {
+        x: singleNode.position.x,
+        y: singleNode.position.y,
+      },
+    };
+  }
+
+  const horizontalGap = options.horizontalGap ?? HORIZONTAL_GAP;
+  const verticalGap = options.verticalGap ?? VERTICAL_GAP;
+  const componentGap = options.componentGap ?? COMPONENT_GAP;
+  const originX = options.origin?.x ?? 0;
+  const originY = options.origin?.y ?? 0;
+
+  const nodeMap = new Map<string, ChatNode>();
+  const metrics = new Map<string, NodeMetrics>();
+
+  for (const node of nodes) {
+    nodeMap.set(node.id, node);
+    metrics.set(node.id, {
+      width: (node.style?.width as number) ?? NODE_WIDTH,
+      height: (node.style?.height as number) ?? NODE_HEIGHT,
+    });
+  }
+
+  const childMap = new Map<string, string[]>();
+  const parentMap = new Map<string, string[]>();
+  const indegree = new Map<string, number>();
+
+  for (const node of nodes) {
+    childMap.set(node.id, []);
+    parentMap.set(node.id, []);
+    indegree.set(node.id, 0);
+  }
+
+  for (const edge of edges) {
+    if (!nodeMap.has(edge.source) || !nodeMap.has(edge.target)) continue;
+    childMap.get(edge.source)!.push(edge.target);
+    parentMap.get(edge.target)!.push(edge.source);
+    indegree.set(edge.target, (indegree.get(edge.target) ?? 0) + 1);
+  }
+
+  const roots = nodes
+    .filter((node) => (indegree.get(node.id) ?? 0) === 0)
+    .sort((a, b) => a.position.y - b.position.y || a.id.localeCompare(b.id));
+
+  const queue: string[] = roots.map((node) => node.id);
+  const depth = new Map<string, number>();
+  const indegreeWork = new Map(indegree);
+
+  for (const root of roots) {
+    depth.set(root.id, 0);
+  }
+
+  while (queue.length > 0) {
+    const currentId = queue.shift()!;
+    const currentDepth = depth.get(currentId) ?? 0;
+
+    for (const childId of childMap.get(currentId) ?? []) {
+      const childDepth = depth.get(childId);
+      const nextDepth = currentDepth + 1;
+      if (childDepth === undefined || nextDepth > childDepth) {
+        depth.set(childId, nextDepth);
+      }
+
+      const nextIndegree = (indegreeWork.get(childId) ?? 0) - 1;
+      indegreeWork.set(childId, nextIndegree);
+      if (nextIndegree === 0) {
+        queue.push(childId);
+      }
+    }
+  }
+
+  for (const node of nodes) {
+    if (!depth.has(node.id)) {
+      const parentDepths = (parentMap.get(node.id) ?? [])
+        .map((parentId) => depth.get(parentId))
+        .filter((d): d is number => d !== undefined);
+      depth.set(
+        node.id,
+        parentDepths.length > 0 ? Math.max(...parentDepths) + 1 : 0
+      );
+    }
+  }
+
+  const undirectedAdjacency = new Map<string, Set<string>>();
+  for (const node of nodes) {
+    undirectedAdjacency.set(node.id, new Set());
+  }
+  for (const edge of edges) {
+    if (!nodeMap.has(edge.source) || !nodeMap.has(edge.target)) continue;
+    undirectedAdjacency.get(edge.source)!.add(edge.target);
+    undirectedAdjacency.get(edge.target)!.add(edge.source);
+  }
+
+  const components: string[][] = [];
+  const visited = new Set<string>();
+  const nodeIdsByTop = [...nodes]
+    .sort((a, b) => a.position.y - b.position.y || a.id.localeCompare(b.id))
+    .map((node) => node.id);
+
+  for (const startId of nodeIdsByTop) {
+    if (visited.has(startId)) continue;
+    const component: string[] = [];
+    const stack = [startId];
+    visited.add(startId);
+    while (stack.length > 0) {
+      const id = stack.pop()!;
+      component.push(id);
+      for (const neighbor of undirectedAdjacency.get(id) ?? []) {
+        if (visited.has(neighbor)) continue;
+        visited.add(neighbor);
+        stack.push(neighbor);
+      }
+    }
+    components.push(component);
+  }
+
+  const result = new Map<string, { x: number; y: number }>();
+  let currentComponentTop = originY;
+
+  for (const componentNodeIds of components) {
+    const nodesByDepth = new Map<number, string[]>();
+    let maxDepth = 0;
+
+    for (const nodeId of componentNodeIds) {
+      const d = depth.get(nodeId) ?? 0;
+      maxDepth = Math.max(maxDepth, d);
+      const group = nodesByDepth.get(d) ?? [];
+      group.push(nodeId);
+      nodesByDepth.set(d, group);
+    }
+
+    for (const [d, ids] of nodesByDepth) {
+      ids.sort((a, b) => {
+        const ay = nodeMap.get(a)!.position.y;
+        const by = nodeMap.get(b)!.position.y;
+        return ay - by || a.localeCompare(b);
+      });
+      nodesByDepth.set(d, ids);
+    }
+
+    const columnWidths: number[] = [];
+    for (let d = 0; d <= maxDepth; d += 1) {
+      const ids = nodesByDepth.get(d) ?? [];
+      let width = NODE_WIDTH;
+      for (const id of ids) {
+        width = Math.max(width, metrics.get(id)!.width);
+      }
+      columnWidths[d] = width;
+    }
+
+    const columnX: number[] = [];
+    columnX[0] = originX;
+    for (let d = 1; d <= maxDepth; d += 1) {
+      columnX[d] = columnX[d - 1] + columnWidths[d - 1] + horizontalGap;
+    }
+
+    const centerY = new Map<string, number>();
+    const depthZeroIds = nodesByDepth.get(0) ?? [];
+
+    let nextCenter = 0;
+    for (const id of depthZeroIds) {
+      const height = metrics.get(id)!.height;
+      centerY.set(id, nextCenter + height / 2);
+      nextCenter += height + verticalGap;
+    }
+
+    for (let d = 0; d < maxDepth; d += 1) {
+      const ids = nodesByDepth.get(d) ?? [];
+
+      for (const parentId of ids) {
+        const children = (childMap.get(parentId) ?? [])
+          .filter((childId) => (depth.get(childId) ?? 0) === d + 1)
+          .sort((a, b) => {
+            const ay = nodeMap.get(a)!.position.y;
+            const by = nodeMap.get(b)!.position.y;
+            return ay - by || a.localeCompare(b);
+          });
+
+        if (children.length === 0) continue;
+
+        const parentCenter = centerY.get(parentId) ?? 0;
+        const totalChildrenHeight = children.reduce(
+          (sum, childId) => sum + metrics.get(childId)!.height,
+          0
+        );
+        const totalHeight =
+          totalChildrenHeight + verticalGap * (children.length - 1);
+
+        let cursor = parentCenter - totalHeight / 2;
+        for (const childId of children) {
+          const childHeight = metrics.get(childId)!.height;
+          const proposal = cursor + childHeight / 2;
+          const existing = centerY.get(childId);
+          centerY.set(
+            childId,
+            existing === undefined ? proposal : (existing + proposal) / 2
+          );
+          cursor += childHeight + verticalGap;
+        }
+      }
+
+      const nextDepthIds = (nodesByDepth.get(d + 1) ?? []).sort((a, b) => {
+        const ay = centerY.get(a) ?? nodeMap.get(a)!.position.y;
+        const by = centerY.get(b) ?? nodeMap.get(b)!.position.y;
+        return ay - by || a.localeCompare(b);
+      });
+
+      let previousId: string | undefined;
+      for (const id of nextDepthIds) {
+        if (!centerY.has(id)) {
+          centerY.set(id, nodeMap.get(id)!.position.y + metrics.get(id)!.height / 2);
+        }
+
+        if (previousId === undefined) {
+          previousId = id;
+          continue;
+        }
+
+        const prevCenter = centerY.get(previousId)!;
+        const currentCenter = centerY.get(id)!;
+        const minDistance =
+          metrics.get(previousId)!.height / 2 +
+          metrics.get(id)!.height / 2 +
+          verticalGap;
+        if (currentCenter < prevCenter + minDistance) {
+          centerY.set(id, prevCenter + minDistance);
+        }
+        previousId = id;
+      }
+    }
+
+    let componentMinY = Infinity;
+    let componentMaxY = -Infinity;
+    for (const id of componentNodeIds) {
+      const d = depth.get(id) ?? 0;
+      const x = columnX[d];
+      const y = (centerY.get(id) ?? 0) - metrics.get(id)!.height / 2;
+      result.set(id, { x, y });
+      componentMinY = Math.min(componentMinY, y);
+      componentMaxY = Math.max(componentMaxY, y + metrics.get(id)!.height);
+    }
+
+    const componentHeight = componentMaxY - componentMinY;
+    const yOffset = currentComponentTop - componentMinY;
+    for (const id of componentNodeIds) {
+      const positioned = result.get(id)!;
+      result.set(id, { x: positioned.x, y: positioned.y + yOffset });
+    }
+
+    currentComponentTop += componentHeight + componentGap;
+  }
+
+  return Object.fromEntries(result.entries());
 }


### PR DESCRIPTION
# Summary
Adds an Auto-arrange nodes feature to organize canvas conversations into a readable left-to-right tree layout.

# What changed
- Added an auto-layout control button in canvas controls:
   - src/components/canvas/CanvasControls.tsx
   - Uses Network icon and tooltip: "Auto-arrange nodes"
   - On click, computes layout and applies updated node positions via flowStore.setNodes(...)
- Added new pure layout utility:
   - src/utils/nodeLayout.ts
   - New calculateAutoLayoutPositions(nodes, edges, options) function
   - Handles:
      - Root nodes at leftmost column
      - Children one level to the right
      - Merge nodes at deepest parent level + 1
      - Disconnected subgraphs stacked vertically
      - Node size-aware spacing using existing node dimensions
      - Single-node/no-edge fallback (keeps position)

# preview
<img width="1914" height="899" alt="Screenshot 2026-04-19 172311" src="https://github.com/user-attachments/assets/42b1ba55-2f7f-48ab-9bdb-907266a7aa32" />
<img width="1917" height="897" alt="Screenshot 2026-04-19 172353" src="https://github.com/user-attachments/assets/d1c67fda-d935-4a98-87a1-409b71165c79" />
