### PR TITLE
added feature Support image attachments in chat messages

### DIFF
--- a/src/components/nodes/ChatInput.tsx
+++ b/src/components/nodes/ChatInput.tsx
@@ -1,25 +1,38 @@
-import { useState, useCallback } from 'react';
-import { Send, Square } from 'lucide-react';
+import { useState, useCallback, useRef } from 'react';
+import { Send, Square, Paperclip, X } from 'lucide-react';
 import { useChatStore } from '../../stores/chatStore';
 
 interface ChatInputProps {
   nodeId: string;
-  onSend: (message: string) => void;
+  onSend: (message: string, images: File[]) => void;
   onCancel: () => void;
+  supportsVision?: boolean;
 }
 
-export function ChatInput({ nodeId, onSend, onCancel }: ChatInputProps) {
+export function ChatInput({
+  nodeId,
+  onSend,
+  onCancel,
+  supportsVision = true,
+}: ChatInputProps) {
   const [input, setInput] = useState('');
+  const [images, setImages] = useState<File[]>([]);
+  const [isDragging, setIsDragging] = useState(false);
+
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+
   const isStreaming = useChatStore(
     (s) => s.conversations[nodeId]?.isStreaming ?? false
   );
 
   const handleSend = useCallback(() => {
     const trimmed = input.trim();
-    if (!trimmed || isStreaming) return;
+    if ((!trimmed && images.length === 0) || isStreaming) return;
+
+    onSend(trimmed, images);
     setInput('');
-    onSend(trimmed);
-  }, [input, isStreaming, onSend]);
+    setImages([]);
+  }, [input, images, isStreaming, onSend]);
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
     if (e.key === 'Enter' && !e.shiftKey) {
@@ -28,13 +41,86 @@ export function ChatInput({ nodeId, onSend, onCancel }: ChatInputProps) {
     }
   };
 
+  const handleFileSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (!e.target.files) return;
+
+    const files = Array.from(e.target.files).filter((f) =>
+      f.type.startsWith('image/')
+    );
+
+    setImages((prev) => [...prev, ...files]);
+  };
+
+  const handleDrop = (e: React.DragEvent) => {
+    e.preventDefault();
+    setIsDragging(false);
+
+    const files = Array.from(e.dataTransfer.files).filter((f) =>
+      f.type.startsWith('image/')
+    );
+
+    setImages((prev) => [...prev, ...files]);
+  };
+
+  const handlePaste = (e: React.ClipboardEvent) => {
+    const items = e.clipboardData.items;
+
+    for (const item of items) {
+      if (item.type.startsWith('image/')) {
+        const file = item.getAsFile();
+        if (file) {
+          setImages((prev) => [...prev, file]);
+        }
+      }
+    }
+  };
+
+  const removeImage = (index: number) => {
+    setImages((prev) => prev.filter((_, i) => i !== index));
+  };
+
   return (
-    <div className="nodrag nopan border-t border-neutral-700/50 p-2">
+    <div
+      className={`nodrag nopan border-t border-neutral-700/50 p-2 transition ${
+        isDragging ? 'bg-neutral-700/30' : ''
+      }`}
+      onDragOver={(e) => {
+        e.preventDefault();
+        setIsDragging(true);
+      }}
+      onDragLeave={() => setIsDragging(false)}
+      onDrop={handleDrop}
+    >
+      {images.length > 0 && (
+        <div className="flex gap-2 mb-2 flex-wrap">
+          {images.map((file, i) => (
+            <div
+              key={i}
+              className="relative w-16 h-16 rounded-md overflow-hidden border border-neutral-600"
+            >
+              <img
+                src={URL.createObjectURL(file)}
+                className="w-full h-full object-cover"
+              />
+              <button
+                onClick={() => removeImage(i)}
+                className="absolute top-1 right-1 bg-black/60 rounded-full p-0.5"
+              >
+                <X size={12} />
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+
       <div className="flex items-end gap-1.5">
+        
+
         <textarea
           value={input}
           onChange={(e) => setInput(e.target.value)}
           onKeyDown={handleKeyDown}
+          onPaste={handlePaste}
           placeholder="Ask something..."
           rows={1}
           className="flex-1 resize-none bg-neutral-800/50 text-sm text-neutral-200 rounded-lg px-3 py-2 placeholder-neutral-500 border border-neutral-700/50 focus:border-accent-500/50 focus:outline-none transition-colors"
@@ -42,23 +128,45 @@ export function ChatInput({ nodeId, onSend, onCancel }: ChatInputProps) {
           onInput={(e) => {
             const target = e.target as HTMLTextAreaElement;
             target.style.height = 'auto';
-            target.style.height = Math.min(target.scrollHeight, 100) + 'px';
+            target.style.height =
+              Math.min(target.scrollHeight, 100) + 'px';
           }}
         />
+
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept="image/*"
+          multiple
+          hidden
+          onChange={handleFileSelect}
+        />
+
+        <button
+          onClick={() => fileInputRef.current?.click()}
+          disabled={!supportsVision}
+          className="shrink-0 p-2 rounded-lg bg-neutral-800/60 text-neutral-300 hover:bg-neutral-700 transition disabled:opacity-30"
+          title={
+            supportsVision
+              ? 'Attach image'
+              : 'Images not supported by provider'
+          }
+        >
+          <Paperclip size={16} />
+        </button>
+
         {isStreaming ? (
           <button
             onClick={onCancel}
             className="shrink-0 p-2 rounded-lg bg-red-500/20 text-red-400 hover:bg-red-500/30 transition-colors"
-            title="Stop"
           >
             <Square size={16} />
           </button>
         ) : (
           <button
             onClick={handleSend}
-            disabled={!input.trim()}
-            className="shrink-0 p-2 rounded-lg bg-accent-500/20 text-accent-400 hover:bg-accent-500/30 transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
-            title="Send"
+            disabled={!input.trim() && images.length === 0}
+            className="shrink-0 p-2 rounded-lg bg-accent-500/20 text-accent-400 hover:bg-accent-500/30 transition-colors disabled:opacity-30"
           >
             <Send size={16} />
           </button>

--- a/src/components/nodes/ChatMessage.tsx
+++ b/src/components/nodes/ChatMessage.tsx
@@ -65,6 +65,7 @@ export const ChatMessage = memo(function ChatMessage({
   const isUser = message.role === 'user';
   const isSystem = message.role === 'system';
   const [copied, setCopied] = useState(false);
+  const [lightbox, setLightbox] = useState<string | null>(null);
   const resetTimeoutRef = useRef<number | null>(null);
 
   const handleCopy = useCallback(async () => {
@@ -89,6 +90,15 @@ export const ChatMessage = memo(function ChatMessage({
         window.clearTimeout(resetTimeoutRef.current);
       }
     };
+  }, []);
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setLightbox(null);
+    };
+
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
   }, []);
 
   const withHighlights = (children: ReactNode) =>
@@ -128,8 +138,22 @@ export const ChatMessage = memo(function ChatMessage({
           {copied ? <Check size={14} /> : <Copy size={14} />}
         </button>
         {isUser ? (
-          message.content
-        ) : (
+            <div className="flex flex-col gap-2">
+              {message?.images?.map((img, i) => {
+                const url = `data:${img.mimeType};base64,${img.base64}`;
+
+                return (
+                  <img
+                    key={i}
+                    src={url}
+                    onClick={() => setLightbox(url)}
+                    className="max-w-25 sm:max-w-25 rounded-lg cursor-pointer border border-neutral-700 hover:opacity-90 transition"
+                  />
+                );
+              })}
+              {message.content && <div>{message.content}</div>}
+            </div>
+          ) : (
           <Markdown
             remarkPlugins={[remarkGfm]}
             components={{
@@ -240,6 +264,19 @@ export const ChatMessage = memo(function ChatMessage({
           </Markdown>
         )}
       </div>
+
+      {lightbox && (
+        <div
+          className="fixed inset-0 bg-black/80 flex items-center justify-center z-50"
+          onClick={() => setLightbox(null)}
+        >
+          <img
+            src={lightbox}
+            className="max-w-[90%] max-h-[90%] rounded-lg shadow-xl"
+            onClick={(e) => e.stopPropagation()}
+          />
+        </div>
+      )}
     </div>
   );
 });

--- a/src/hooks/useChatNode.ts
+++ b/src/hooks/useChatNode.ts
@@ -4,15 +4,21 @@ import { streamChat } from '../services/llm';
 import { getRootSystemPrompt, getBranchSystemPrompt, getMergeSystemPrompt } from '../utils/systemPrompts';
 import { useFlowStore } from '../stores/flowStore';
 import type { ChatMessage } from '../types/chat';
+import { validateImage, fileToBase64 } from '../utils/image';
 
 export function useChatNode(nodeId: string, topic: string, parentNodeId?: string, branchText?: string, parentNodeIds?: string[], mergeAction?: string) {
   const abortRef = useRef<AbortController | null>(null);
 
   const sendMessage = useCallback(
-    (content: string) => {
+    async(content: string, files: File[] = []) => {
+      const processedImages = await Promise.all(
+        files.map(async (file) => {
+          validateImage(file);
+          return await fileToBase64(file);
+        })
+      );      
       const store = useChatStore.getState();
-      store.addMessage(nodeId, 'user', content);
-
+      store.addMessage(nodeId, 'user', content, processedImages);
       const messages = store.getMessages(nodeId);
 
       // Build messages array with system prompt

--- a/src/services/providers/anthropic.ts
+++ b/src/services/providers/anthropic.ts
@@ -1,6 +1,29 @@
 import type { LLMProvider, StreamCallbacks } from './types';
 import type { ChatMessage, LLMConfig } from '../../types/chat';
 
+function toAnthropicMessages(messages: ChatMessage[]) {
+  return messages.map((m) => {
+    if (m.images && m.images.length > 0) {
+      return {
+        role: m.role,
+        content: [
+          ...m.images.map((img) => ({
+            type: 'image',
+            source: {
+              type: 'base64',
+              media_type: img.mimeType,
+              data: img.base64,
+            },
+          })),
+          ...(m.content ? [{ type: 'text', text: m.content }] : []),
+        ],
+      };
+    }
+
+    return { role: m.role, content: m.content };
+  });
+}
+
 export const AnthropicProvider: LLMProvider = {
   id: 'anthropic',
   name: 'Anthropic',
@@ -20,7 +43,7 @@ export const AnthropicProvider: LLMProvider = {
 
     const body: Record<string, unknown> = {
       model: config.model,
-      messages: nonSystemMessages.map((m) => ({ role: m.role, content: m.content })),
+      messages: toAnthropicMessages(nonSystemMessages),
       max_tokens: config.maxTokens,
       temperature: config.temperature,
       stream: true,
@@ -85,10 +108,13 @@ export const AnthropicProvider: LLMProvider = {
             }
           } catch (e) {
             if (e instanceof Error && e.message.startsWith('API error')) throw e;
+
             if (e instanceof Error && e.message !== 'Unknown stream error' &&
                 !e.message.includes('stream error')) {
-              // skip malformed JSON lines
-            } else if (e instanceof Error) {
+              continue;
+            }
+
+            if (e instanceof Error) {
               throw e;
             }
           }

--- a/src/services/providers/mock.ts
+++ b/src/services/providers/mock.ts
@@ -13,7 +13,12 @@ const MOCK_RESPONSES: Record<string, string[]> = {
 
 function getResponseForTopic(messages: ChatMessage[]): string {
   const lastUserMsg = [...messages].reverse().find((m) => m.role === 'user');
-  const topic = lastUserMsg?.content ?? '';
+
+  const topic =
+    lastUserMsg?.content ||
+    (lastUserMsg?.images && lastUserMsg.images.length > 0
+      ? 'image'
+      : '');
 
   const responses = MOCK_RESPONSES.default;
   const hash = topic.split('').reduce((acc, c) => acc + c.charCodeAt(0), 0);
@@ -23,6 +28,7 @@ function getResponseForTopic(messages: ChatMessage[]): string {
 export const MockProvider: LLMProvider = {
   id: 'mock',
   name: 'Mock (Development)',
+  supportsVision: false,
 
   streamChat(
     messages: ChatMessage[],

--- a/src/services/providers/openai.ts
+++ b/src/services/providers/openai.ts
@@ -1,9 +1,45 @@
 import type { LLMProvider, StreamCallbacks } from './types';
 import type { ChatMessage, LLMConfig } from '../../types/chat';
 
+function toOpenAIMessages(messages: ChatMessage[]) {
+  return messages.map((m, index) => {
+    const isLast = index === messages.length - 1;
+
+    const validImages =
+      isLast
+        ? m.images?.filter(
+            (img) =>
+              img &&
+              img.base64 &&
+              img.mimeType?.startsWith('image/')
+          ) || []
+        : []; 
+
+    if (validImages.length > 0) {
+      return {
+        role: m.role,
+        content: [
+          ...(m.content
+            ? [{ type: 'text', text: m.content }]
+            : []),
+          ...validImages.map((img) => ({
+            type: 'image_url',
+            image_url: {
+              url: `data:${img.mimeType};base64,${img.base64}`,
+            },
+          })),
+        ],
+      };
+    }
+
+    return { role: m.role, content: m.content };
+  });
+}
+
 export const OpenAIProvider: LLMProvider = {
   id: 'openai',
   name: 'OpenAI',
+  supportsVision: true,
 
   async streamChat(
     messages: ChatMessage[],
@@ -16,7 +52,7 @@ export const OpenAIProvider: LLMProvider = {
 
     const body = {
       model: config.model,
-      messages: messages.map((m) => ({ role: m.role, content: m.content })),
+      messages: toOpenAIMessages(messages),
       temperature: config.temperature,
       max_completion_tokens: config.maxTokens,
       stream: true,
@@ -68,7 +104,7 @@ export const OpenAIProvider: LLMProvider = {
               callbacks.onToken(content);
             }
           } catch {
-            // skip malformed JSON lines
+              continue;
           }
         }
       }

--- a/src/services/providers/types.ts
+++ b/src/services/providers/types.ts
@@ -15,4 +15,5 @@ export interface LLMProvider {
     callbacks: StreamCallbacks,
     signal: AbortSignal
   ) => void;
+  supportsVision?: boolean;
 }

--- a/src/stores/chatStore.ts
+++ b/src/stores/chatStore.ts
@@ -5,7 +5,10 @@ import type { ChatMessage, Conversation, MessageRole } from '../types/chat';
 interface ChatState {
   conversations: Record<string, Conversation>;
   initConversation: (nodeId: string) => void;
-  addMessage: (nodeId: string, role: MessageRole, content: string) => string;
+  addMessage: (nodeId: string, role: MessageRole, content: string, images?: {
+    base64: string;
+    mimeType: string;
+  }[]) => string;
   appendToLastMessage: (nodeId: string, chunk: string) => void;
   setStreaming: (nodeId: string, streaming: boolean) => void;
   getMessages: (nodeId: string) => ChatMessage[];
@@ -26,9 +29,9 @@ export const useChatStore = create<ChatState>((set, get) => ({
     });
   },
 
-  addMessage: (nodeId, role, content) => {
+  addMessage: (nodeId, role, content,images) => {
     const id = nanoid();
-    const message: ChatMessage = { id, role, content, timestamp: Date.now() };
+    const message: ChatMessage = { id, role, content, timestamp: Date.now(),images };
     const conv = get().conversations[nodeId];
     if (!conv) return id;
     set({

--- a/src/types/chat.ts
+++ b/src/types/chat.ts
@@ -5,7 +5,10 @@ export interface ChatMessage {
   role: MessageRole;
   content: string;
   timestamp: number;
-}
+  images?: {
+    base64: string;
+    mimeType: string;
+  }[];}
 
 export interface Conversation {
   nodeId: string;

--- a/src/utils/image.ts
+++ b/src/utils/image.ts
@@ -1,0 +1,34 @@
+export const MAX_SIZE_MB = 5;
+
+const ALLOWED_TYPES = ['image/png', 'image/jpeg', 'image/webp'];
+
+export function validateImage(file: File) {
+  if (!ALLOWED_TYPES.includes(file.type)) {
+    throw new Error(`Invalid file type: ${file.type}`);
+  }
+
+  if (file.size > MAX_SIZE_MB * 1024 * 1024) {
+    throw new Error('Image too large (max 5MB)');
+  }
+}
+
+export async function fileToBase64(file: File): Promise<{
+  base64: string;
+  mimeType: string;
+}> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+
+    reader.onload = () => {
+      const result = reader.result as string;
+      const base64 = result.split(',')[1];
+
+      resolve({
+        base64,
+        mimeType: file.type || 'image/png',      });
+    };
+
+    reader.onerror = reject;
+    reader.readAsDataURL(file);
+  });
+}


### PR DESCRIPTION
***Summary*** 

Users can drag-and-drop or paste images into the chat input. The image appears as a preview in the input area, gets sent alongside the text message, and displays inline in the conversation history. Vision-capable
models analyze the image in context.

**Feature**
* Add a small attachment button (e.g. Paperclip or ImagePlus icon from lucide-react) next to the send button
* Clicking it opens a native file picker filtered to images (accept="image/*")
* Support drag-and-drop onto the input area — show a drop zone highlight when dragging
* Support paste (Ctrl+V / Cmd+V) — detect image data on the clipboard
* Show image previews as small thumbnails below the text input with an X button to remove each
* Multiple images per message should be supported (providers typically allow several)
* Disable the attachment button when the active provider is mock or doesn't support vision (see provider capabilities below)
Message Display — ChatMessage.tsx

* Render attachments as inline images above or below the text content in user messages
I* mages should be displayed at a reasonable max width (~300px) with click-to-expand to full size
* Use a lightbox-style overlay for full-size viewing (Escape to close, click backdrop to close)

**preview**
<img width="413" height="416" alt="Screenshot 2026-04-23 at 7 15 38 PM" src="https://github.com/user-attachments/assets/e909000e-0a1b-43bf-9916-969edc85b446" />


<img width="508" height="192" alt="Screenshot 2026-04-23 at 7 16 27 PM" src="https://github.com/user-attachments/assets/f7b63619-1f5f-4a02-b253-893d383c67c8" />

**Closes**
**PR** - #13

**Note**
Please review the changes, Thanks

 


