### PR TITLE
implemented feature collapse/expand all nodes button to canvas controls

### DIFF
--- a/src/components/canvas/CanvasControls.tsx
+++ b/src/components/canvas/CanvasControls.tsx
@@ -9,6 +9,8 @@ import {
   Plus,
   HelpCircle,
   Network,
+  ChevronDownSquare,
+  ChevronUpSquare
 } from 'lucide-react';
 import { useSettingsStore } from '../../stores/settingsStore';
 import { useFlowStore } from '../../stores/flowStore';
@@ -23,6 +25,11 @@ export function CanvasControls() {
   const toggleSettings = useSettingsStore((s) => s.toggleSettings);
   const [showHelp, setShowHelp] = useState(false);
   const arrangeTimerRef = useRef<number | null>(null);
+  const toggleCollapseSmart = useFlowStore((s) => s.toggleCollapseSmart);
+
+  const nodes = useFlowStore((s) => s.nodes);
+  const collapsedCount = nodes.filter((n) => n.data?.collapsed).length;
+  const mostlyCollapsed = collapsedCount > nodes.length / 2;
 
   useEffect(() => {
     return () => {
@@ -109,6 +116,13 @@ export function CanvasControls() {
           title="Toggle Minimap"
         >
           <Map size={18} />
+        </button>
+        <button  
+          onClick={toggleCollapseSmart}
+          className={btnClass}
+          title="Toggle Collapse All"
+        >
+          {mostlyCollapsed ? <ChevronUpSquare size={18} /> : <ChevronDownSquare size={18} />}        
         </button>
         <button onClick={toggleSettings} className={btnClass} title="Settings">
           <Settings size={18} />

--- a/src/stores/flowStore.ts
+++ b/src/stores/flowStore.ts
@@ -22,6 +22,7 @@ interface FlowState {
   setNodes: (nodes: ChatNode[]) => void;
   setEdges: (edges: TopicEdge[]) => void;
   getChildCount: (parentId: string) => number;
+  toggleCollapseSmart: () => void;
 }
 
 export const useFlowStore = create<FlowState>((set, get) => ({
@@ -91,4 +92,25 @@ export const useFlowStore = create<FlowState>((set, get) => ({
   getChildCount: (parentId) => {
     return get().edges.filter((e) => e.source === parentId).length;
   },
+
+  toggleCollapseSmart: () => {
+  const nodes = get().nodes;
+
+  if (nodes.length === 0) return;
+
+  const collapsedCount = nodes.filter((n) => n.data?.collapsed).length;
+
+  const shouldCollapse = collapsedCount < nodes.length / 2;
+
+  set({
+    nodes: nodes.map((n) => ({
+      ...n,
+      data: {
+        ...n.data,
+        collapsed: shouldCollapse,
+      },
+    })),
+  });
+},
+  
 }));


### PR DESCRIPTION
**Summary**

Add collapse/expand all nodes button to canvas controls

**Feature**

Add a toggle button to the canvas controls toolbar (left side) that collapses or expands all nodes at once. When most nodes are expanded, clicking it collapses all. When most are collapsed, clicking it expands all.

**preview**

1 :
<img width="93" height="428" alt="Screenshot 2026-04-26 at 10 18 37 AM" src="https://github.com/user-attachments/assets/768ef947-56e5-4ee4-9721-484afc848ab5" />

2 :
<img width="952" height="780" alt="Screenshot 2026-04-26 at 10 19 01 AM" src="https://github.com/user-attachments/assets/1eead199-00d7-4358-bed3-3f87c30e661f" />

3 :
<img width="1078" height="765" alt="Screenshot 2026-04-26 at 10 18 50 AM" src="https://github.com/user-attachments/assets/beb378b9-98d6-479c-9de7-ca41c77617ae" />


Closes
Issue : #4


**Note** 
Please review the changes 
Thanks.